### PR TITLE
Use defined labels instead of hard-coding the addresses.

### DIFF
--- a/drhooks.asm
+++ b/drhooks.asm
@@ -104,11 +104,9 @@ nop : stz $0dd0, X : rts
 .not_in_ganons_tower
 
 
-;org $208206
-org $20820E
+org DoWorldFix_doors_mirror_override
 jsl MirrorCheckOverride2
-;org $208270
-org $20827C
+org DoWorldFix_Inverted_doors_mirror_override
 jsl MirrorCheckOverride2
 org $07a955 ; <- Bank07.asm : around 6564 (JP is a bit different) (STZ $05FC : STZ $05FD)
 jsl BlockEraseFix
@@ -133,8 +131,7 @@ jsl SuctionOverworldFix
 
 ; also rando's hooks.asm line 1360
 ; 106e4e -> goes to  a0ee4e
-;org $a0ee8a ; <- 6FC4C - headsup_display.asm : 836 (LDA $7EF36E : AND.w #$00FF : ADD.w #$0007 : AND.w #$FFF8 : TAX)
-org $a0eeab
+org OnDrawHud_DrHudOverride ; <- 6FC4C - headsup_display.asm : 836 (LDA $7EF36E : AND.w #$00FF : ADD.w #$0007 : AND.w #$FFF8 : TAX)
 jsl DrHudOverride
 org $0ded04 ; <- rando's hooks.asm line 2192 - 6ED04 - equipment.asm : 1963 (REP #$30)
 jsl DrHudDungeonItemsAdditions

--- a/stats.asm
+++ b/stats.asm
@@ -263,6 +263,7 @@ RTL
 ;--------------------------------------------------------------------------------
 CountChestKey: ; called by neighbor functions
     PHA : PHX
+        lda !MULTIWORLD_ITEM_PLAYER_ID : bne .end
         CPY #$24 : BEQ +  ; small key for this dungeon - use $040C
         CPY #$A0 : !BLT .end ; Ignore most items
         CPY #$AE : !BGE .end ; Ignore reserved key and generic key


### PR DESCRIPTION
Labels for MirrorCheckOverride,  InvertedMirrorCheckOverride, and DrHudOverride.