### PR TITLE
Shuffle in-room stairs

### DIFF
--- a/doorrando.asm
+++ b/doorrando.asm
@@ -7,6 +7,8 @@
 ; Free RAM notes
 ; Normal doors use $AB-AC for scrolling indicator
 ; Normal doors use $FE to store the trap door indicator
+; Normal doors use $045e to store Y coordinate when transitioning to in-room stairs
+; Normal doors use $045f to determine the order in which supertile quadrants are drawn
 ; Spiral doors use $045e to store stair type
 ; Gfx uses $b1 to for sub-sub-sub-module thing
 
@@ -35,7 +37,7 @@ incsrc edges.asm
 incsrc math.asm
 incsrc hudadditions.asm
 incsrc dr_lobby.asm
-warnpc $279700
+warnpc $279C00
 
 incsrc doortables.asm
 warnpc $288000

--- a/doortables.asm
+++ b/doortables.asm
@@ -1,4 +1,4 @@
-org $279700
+org $279C00
 KeyDoorOffset:
 ;      0     1     2     3     4     5     6     7     8     9     a     b     c     d     e     f --Offset Ruler
 dw $0000,$0001,$0003,$0000,$0006,$0000,$000b,$0000,$0000,$0000,$000c,$000d,$0010,$0011,$0012,$0000
@@ -58,7 +58,7 @@ db $9f
 
 org $27A000
 DoorTable:
-;; NW 00  N  01  N  02  WN 00  W  01  WS 02  SW 00  S  01  SE 02  EN 00  E  01  ES 02 - Door ruler
+;; NW 00  N  01  NE 02  WN 00  W  01  WS 02  SW 00  S  01  SE 02  EN 00  E  01  ES 02 - Door ruler
 dw $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003 ; Default/Garbage row
 dw $0003, $0003, $0003, $0450, $0003, $0003, $0003, $0003, $0003, $0452, $0003, $0003 ; HC Back Hall (x01)
 dw $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003 ; Sewer Switches (x02)
@@ -227,7 +227,7 @@ dw $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, $0003, 
 ;dw $0080, $1f50 ; ->zelda's cellblock
 
 org $27B000
-SpiralTable: ;113 4 byte entries - should end at 27B44C
+SpiralTable: ;113 4 byte entries - should end at 27B1C4
 dw $0203, $8080 ;null row
 dw $0203, $8080 ;HC Backhallway
 dw $0203, $8080 ;Sewer Pull
@@ -556,6 +556,20 @@ db $58,$50,$30 ; TT Nook
 MultDivInfo: ; (1, 2, 3, 4, 5, 6, 10, 20)
 db $01, $02, $03, $04, $05, $06, $0a, $14
 ; indices: 0-7
+
+; In-room stairs in North/South pairs. From left to right:
+; PoD, IP right side, IP Freezor chest and GT
+org $27C700
+InroomStairsTable:
+dw $0003,$0003, $0003,$0003, $0003,$0003, $0003,$0003
+
+org $27C720
+InroomStairsRoom:
+db $0B,$1B, $3F,$1F, $7E,$5E, $96,$3D
+InroomStairsX:
+dw $0190, $0160, $0040, $0178
+InroomStairsY:
+dw $0058, $0148, $0198, $0190
 
 
 ; dungeon tables

--- a/drhooks.asm
+++ b/drhooks.asm
@@ -46,8 +46,19 @@ org $029396 ; <- 11396 - Bank02.asm : 3641 (LDA $01C322, X)
 jsl StraightStairLayerFix
 org $02c06d ; <- Bank02.asm : 9874 (LDX $0418, CMP.b #$02)
 jsl DoorToStraight : nop
+org $02c092 ; STA $0020, Y : LDX #$00
+jsl DoorToInroom : nop
+org $02c0f8 ; CMP $02C034, X
+jsl DoorToInroomEnd
 org $02941a ; <- Bank02.asm : 3748 module 7.12.11 (LDA $0464 : BNE BRANCH_$11513 : INC $B0 : RTS)
 jsl StraightStairsTrapDoor : rts
+org $028b54 ; <- Bank02.asm : 2200 (JSL UseImplicitRegIndexedLocalJumpTable)
+jsl InroomStairsTrapDoor
+
+org $0289a0 ; JSL $0091C4
+jsl QuadrantLoadOrderBeforeScroll
+org $02bd9c ; JSL $0091C4
+jsl QuadrantLoadOrderAfterScroll
 
 
 ; Graphics fix

--- a/edges.asm
+++ b/edges.asm
@@ -52,14 +52,20 @@ LoadEdgeRoomVert:
     lda $03 : sta $a0
     sty $06
     and.b #$f0 : lsr #3 : !sub $21 : !add $06 : sta $02
-    ldy #$01 : jsr ShiftVariablesMainDir
 
     lda $04 : and #$80 : bne .edge
     lda $04 : sta $01 ; load up flags in $01
+    and #$03 : cmp #$03 : beq .inroom
+    ldy #$01 : jsr ShiftVariablesMainDir
     jsr PrepScrollToNormal
     bra .scroll
 
+    .inroom
+    jsr ScrollToInroomStairs
+    rts
+
     .edge
+    ldy #$01 : jsr ShiftVariablesMainDir
     lda $04 : and #$10 : beq +
        lda #$01
     + sta $ee ; layer stuff

--- a/overrides.asm
+++ b/overrides.asm
@@ -37,6 +37,8 @@ OnFileLoadOverride:
     jsl OnFileLoad ; what I wrote over
     lda.l DRFlags : and #$80 : beq +  ;flag is off
         lda $7ef086 : ora #$80 : sta $7ef086
+    + lda.l DRFlags : and #$40 : beq +  ;flag is off
+        lda $7ef036 : ora #$80 : sta $7ef036
     + lda.l DRFlags : and #$02 : beq +
         lda $7ef353 : bne +
             lda #$01 : sta $7ef353

--- a/scroll.asm
+++ b/scroll.asm
@@ -204,3 +204,17 @@ ApplyScroll:
     sta $00e2, y
     sta $00e0, y
     stz $ab : sep #$30 : rts
+
+QuadrantLoadOrderBeforeScroll:
+    lda $045f : beq .end
+    lda #$08 : sta $045c ; start with opposite quadrant row
+    .end
+    jsl $0091c4 ; what we overwrote
+    rtl
+
+QuadrantLoadOrderAfterScroll:
+    lda $045f : beq .end
+    stz $045c : stz $045f ; draw other row and clear flag
+    .end
+    jsl $0091c4 ; what we overwrote
+    rtl

--- a/spiral.asm
+++ b/spiral.asm
@@ -2,9 +2,10 @@ RecordStairType: {
     pha
     lda.l DRMode : beq .norm
     lda $040c : cmp #$ff : beq .norm
-         lda $0e : sta $045e
-         cmp #$26 : beq .norm ; skipping in-floor staircases
-            pla : bra +
+        lda $0e
+        cmp #$25 : bcc ++ ; don't record straight staircases
+            sta $045e
+        ++ pla : bra +
     .norm pla : sta $a0
     + lda $063d, x
     rtl
@@ -15,8 +16,13 @@ SpiralWarp: {
     lda $040c : cmp.b #$ff : beq .abort ; abort if not in dungeon
     lda $045e : cmp #$5e : beq .gtg ; abort if not spiral - intended room is in A!
     cmp #$5f : beq .gtg
+    cmp #$26 : beq .inroom
     .abort
     stz $045e : lda $a2 : and #$0f : rtl ; clear,run hijacked code and get out
+    .inroom
+    jsr InroomStairsWarp
+    lda $a2 : and #$0f ; this is the code we are hijacking
+    rtl
 
     .gtg
     phb : phk : plb : phx : phy ; push stuff
@@ -70,6 +76,13 @@ SpiralWarp: {
     lda $01 : and #$20 : sta $07 ; zeroVtCam check
     ldy #$01 : jsr SetCamera
 
+    jsr StairCleanup
+    ply : plx : plb ; pull the stuff we pushed
+    lda $a2 : and #$0f ; this is the code we are hijacking
+    rtl
+}
+
+StairCleanup: {
     stz $045e ; clear the staircase flag
 
     ; animated tiles fix
@@ -81,9 +94,7 @@ SpiralWarp: {
             jsl DecompDungAnimatedTiles
     +
     stz $047a
-    ply : plx : plb ; pull the stuff we pushed
-    lda $a2 : and #$0f ; this is the code we are hijacking
-    rtl
+    rts
 }
 
 ;Sets the offset in A
@@ -105,7 +116,7 @@ LookupSpiralOffset: {
     lda $a9 : ora $aa : and #$03 : beq .quad0
     cmp #$01 : beq .quad1
     cmp #$02 : beq .quad2
-    cmp #$03 : beq .quad3
+    bra .quad3
     .quad0
     inc $01 : lda $a2
     cmp #$0c : beq .q0diff ;gt ent
@@ -135,6 +146,103 @@ LookupSpiralOffset: {
     .done
     lda $a2 : tax : lda.w SpiralOffset,x
     !add $01 ;add a thing (0 in easy case)
+    rts
+}
+
+InroomStairsWarp: {
+    phb : phk : plb : phx : phy ; push stuff
+    ; find stairs by room and store index in X
+    lda $a0 : ldx #$07
+    .loop
+        cmp.w InroomStairsRoom,x
+        beq .found
+        dex
+        bne .loop
+    .found
+    rep #$30
+    txa : and #$00ff : asl : tay
+    lda.w InroomStairsTable,y : sta $00
+	sep #$30
+    sta $a0
+
+    ; set position and everything else based on target door type
+    txa : and #$01 : eor #$01 : sta $07
+    ; should be the same as lda $0462 : and #$04 : lsr #2 : eor #$01 : sta $07
+    lda $01 : and #$80 : beq .notEdge
+        lda $07 : sta $03 : beq +
+            lda $01 : jsr LoadSouthMidpoint : sta $22 : lda #$e0
+            bra ++
+        +
+            lda $01 : jsr LoadNorthMidpoint : sta $22 : lda #$1b
+        ++
+        sta $20
+        lda $01 : and #$20 : beq +
+            lda #$01
+        +
+        sta $02
+        stz $07
+        lda $01 : and #$10 : lsr #4
+        brl .layer
+    .notEdge
+    lda $01 : and #$03 : cmp #$03 : bne .normal
+        lda $01 : and #$30 : lsr #3 : tay
+        lda.w InroomStairsX,y : sta $22
+        lda.w InroomStairsX+1,y : sta $02
+        lda.w InroomStairsY+1,y : sta $03
+        lda.w InroomStairsY,y
+        ldy $07 : beq +
+            !add #$07
+        +
+        sta $20
+        %StonewallCheck($1b)
+        inc $07
+        lda $01 : and #$04 : lsr #2
+        bra .layer
+    .normal
+        lda $01 : sta $fe ; trap door
+        lda $07 : sta $03 : beq +
+            lda #$e0
+            ldy $a0 : cpy #$51 : bne ++ ; special fix for throne room
+                !sub #$18
+                bra ++
+        +
+            %StonewallCheck($43)
+            lda #$1b
+        ++
+        sta $20
+        inc $07 : stz $02 : lda #$78 : sta $22
+        lda $01 : and #$03 : beq ++
+            cmp #$02 : !bge +
+                lda #$f8 : sta $22 : stz $07 : bra ++
+            + inc $02
+        ++
+        lda $01 : and #$04 : lsr #2
+
+    .layer
+    sta $ee
+    bne +
+    	stz $0476
+    +
+
+    lda $02 : !sub $a9
+    beq .skipXQuad
+        sta $06 : !add $a9 : sta $a9
+        ldy #$00 : jsr ShiftQuadSimple
+    .skipXQuad
+    lda $aa : lsr : sta $06 : lda $03 : !sub $06
+    beq .skipYQuad
+        sta $06 : asl : !add $aa : sta $aa
+        ldy #$01 : jsr ShiftQuadSimple
+    .skipYQuad
+
+    ldy #$00 : jsr SetCamera ; horizontal camera
+    ldy #$01 : sty $07 : jsr SetCamera ; vertical camera
+    lda $20 : cmp #$e0 : bcc +
+    lda $e8 : bne +
+        lda #$10 : sta $e8 ; adjust vertical camera at bottom
+    +
+    jsr StairCleanup
+    ply : plx : plb ; pull the stuff we pushed
     rts
 }
 


### PR DESCRIPTION
Adds the ability to shuffle the 4 pairs of in-room stairs in dungeons. They can be paired with normal doors, open edges and the other straight staircases.
A stonewall (Desert or PoD) is opened when the player would otherwise transition into one and get stuck.