### PR TITLE
Fixed GT/ToH MSU muting when playing Door Shuffle

### DIFF
--- a/msu.asm
+++ b/msu.asm
@@ -335,6 +335,7 @@ CheckMusicLoadRequest:
 ;--------------------------------------------------------------------------------
 SpiralStairsPreCheck:
     REP #$20    ; thing we wrote over
+    LDA.l DRMode : BNE .done ; exit if door rando enabled
     LDA $A0
     CMP.w #$000C : BNE +
         LDA !REG_CURRENT_MSU_TRACK : AND.w #$00FF : CMP.w #59 : BNE .done
@@ -365,6 +366,7 @@ SpiralStairsPreCheck:
 ;--------------------------------------------------------------------------------
 SpiralStairsPostCheck:
     LDA $A0
+    LDA.l DRMode : BNE .done ; exit if door rando enabled
     CMP.w #$000C : BNE +
         ; Ganon's tower entrance
         LDX $0130 : CPX.b #$F1 : BNE .done  ; Check that we were fading out

--- a/msu.asm
+++ b/msu.asm
@@ -365,8 +365,8 @@ SpiralStairsPreCheck:
 ; Change music on stair transition (ToH/GT)
 ;--------------------------------------------------------------------------------
 SpiralStairsPostCheck:
-    LDA $A0
     LDA.l DRMode : BNE .done ; exit if door rando enabled
+    LDA $A0
     CMP.w #$000C : BNE +
         ; Ganon's tower entrance
         LDX $0130 : CPX.b #$F1 : BNE .done  ; Check that we were fading out


### PR DESCRIPTION
MSU-1 currently fades the music out when going down the spiral stairs in GT and the music fades back in when reaching the GT Lobby.  In Door Shuffle, this room can be anywhere, and there is no instructions to fade any music back in. This fix makes it so the music will continue as in if Door Shuffle is enabled on the seed.