### PR TITLE
Fix junk graphics appearing during GAME OVER screen

### DIFF
--- a/newhud.asm
+++ b/newhud.asm
@@ -150,6 +150,8 @@ SEP #$30
 	CPX #$04 : !BLT .noprize
 	CPX #$08 : BEQ .noprize
 
+	LDA $10 : CMP #$12 : BEQ .noprize
+
 	REP #$20
 
 	LDA.l MapMode


### PR DESCRIPTION
In crystal/pendant dungeons when the C or P is displayed, it turns into a junk graphic during the GAME OVER screen.
This fix just removes the indicator in the GAME OVER screen.

I'm also submitting to the base repo, and it's definitely not urgent, so feel free to wait for it to make its way through the base repo if you'd prefer.