### PR TITLE
Shuffle Back of Tavern

### DIFF
--- a/doorframefixes.asm
+++ b/doorframefixes.asm
@@ -37,3 +37,41 @@ WalkDownIntoTavern:
 	CMP #$43
 RTL
 ;--------------------------------------------------------------------------------
+
+;--------------------------------------------------------------------------------
+; TurnAroundOnUnderworld
+;--------------------------------------------------------------------------------
+TurnAroundOnUnderworld:
+	LDA $26 : BEQ .done
+		; turn around if ($010E == #$43) != ($7F5099 == #$43)
+		LDX #$00
+		LDA #$43 : CMP $010E : BEQ +
+			INX
+		+
+		CMP $7F5099 : BEQ +
+			DEX
+		+
+		CPX #$00 : BEQ .done
+			LDA $26 : EOR #$0C : STA $26
+.done
+JML $0FFD65 ; what we overwrote
+
+;--------------------------------------------------------------------------------
+; TurnUpOnOverworld
+;--------------------------------------------------------------------------------
+TurnUpOnOverworld:
+	LDA.l EntranceTavernBack : CMP #$43 : BEQ .done
+		LDA #$08 : STA $26 ; only fix this glitch if exit not vanilla
+.done
+JML $07E68F ; what we overwrote
+
+;--------------------------------------------------------------------------------
+; WalkUpOnOverworld
+;--------------------------------------------------------------------------------
+WalkUpOnOverworld:
+	LDA $20 : CMP #$091B : BNE .normal ; hardcoded Y coordinate
+		STZ $2F
+		RTL
+	.normal
+	LDA #$0002 : STA $2F ; what we overwrote
+RTL

--- a/hooks.asm
+++ b/hooks.asm
@@ -2887,3 +2887,18 @@ if !FEATURE_NEW_TEXT
     org $0EF285
         JSL RenderCharSetColorExtended_close : NOP
 endif
+;--------------------------------------------------------------------------------
+; Back of tavern fixes
+;--------------------------------------------------------------------------------
+org $028177 ; JSL Underworld_LoadCustomTileAttributes
+JSL TurnAroundOnUnderworld
+
+org $02ABC1 ; JSL Link_HandleMovingAnimation_FullLongEntry
+JSL TurnUpOnOverworld
+
+org $02E297 ; LDA.w #$0002 : STA.b $2F
+JSL WalkUpOnOverworld
+NOP
+
+org $02D7D2 ; BEQ .face_up
+NOP #2 ; this fixes Link's direction after mirroring and falling after entering through back of tavern

--- a/tables.asm
+++ b/tables.asm
@@ -956,6 +956,11 @@ dw #$0000, #$0000
 org $09E3BB ; PC 0x4E3BB
 db $E4 ; Hera Basement Key (Set to programmable HP $EB) (set to $E4 for original hookable/boomable key behavior)
 ;================================================================================
+org $02D7D0 ; PC 0x157D0
+EntranceTavernBack:
+dw $0043 ; Overworld door that leads to back of tavern (update this when this entrance is shuffled)
+; Note: If shuffled, the overworld door on the north side of the tavern is expected to have a Y coordinate of $091B in the exit data (table at $02DDB5)
+;================================================================================
 org $308210 ; PC 0x180210
 RandomizerSeedType:
 db #$00 ; #$00 = Casual (default) - #$01 = Glitched - #$02 = Speedrunner - #$A0 = Super Metroid Combo - #$FF = Not Randomizer


### PR DESCRIPTION
Makes it possible to shuffle the Back of the Tavern entrance.
Generator changes are only required when this entrance is not vanilla (see the comments in tables.asm).