### PR TITLE
Fix issue with rooms $0124-$0127 at Tavern Back

### DIFF
--- a/doorframefixes.asm
+++ b/doorframefixes.asm
@@ -75,3 +75,16 @@ WalkUpOnOverworld:
 	.normal
 	LDA #$0002 : STA $2F ; what we overwrote
 RTL
+
+;--------------------------------------------------------------------------------
+; CheckStairsAdjustment
+;--------------------------------------------------------------------------------
+CheckStairsAdjustment:
+	LDA.b $A0
+	CMP.w #$0124 ; vanilla check, rooms $0124 to $0127 have a lower exit position (currently ER ignores the entrance location)
+	BCC .done
+	LDA.w #$FFFF-1
+	CMP.w $0696 ; tavern back ($0696 == #$FFFF) should always have carry cleared
+.done
+RTL
+; if carry cleared, shift position up

--- a/hooks.asm
+++ b/hooks.asm
@@ -2923,5 +2923,9 @@ org $02E297 ; LDA.w #$0002 : STA.b $2F
 JSL WalkUpOnOverworld
 NOP
 
+org $02E36F
+JSL CheckStairsAdjustment
+NOP
+
 org $02D7D2 ; BEQ .face_up
 NOP #2 ; this fixes Link's direction after mirroring and falling after entering through back of tavern


### PR DESCRIPTION
If one of the rooms $0124-$0127 is placed at the Back of Tavern entrance, exiting that room could sometimes get you stuck inside the tavern on the overworld, forcing a Save&Quit.