### PR TITLE
Add toggle to override aga1 invulnerability in standard

### DIFF
--- a/doorrando/overrides.asm
+++ b/doorrando/overrides.asm
@@ -96,9 +96,13 @@ RetrieveBunnyState:
 ; A should be how much dmg to do to Aga when leaving this function
 StandardAgaDmg:
 	LDX.b #$00 ; part of what we wrote over
-	LDA.l ProgressFlags : AND #$04 : BEQ + ; zelda's not been rescued
+	LDA.l ProgressFlags : AND #$04 : BEQ .checkShouldAgaTakeDamage ; zelda's not been rescued
 		LDA.b #$10 ; hurt him!
-	+ RTL ; A is zero if the AND results in zero and then Agahnim's invincible!
+	.checkShouldAgaTakeDamage ; should be damage aga anyway?
+		LDA.l AllowAgaDamageBeforeZeldaRescued : BEQ .end;
+		LDA.b #$10 ; hurt him!
+	.end
+	+ RTL ; A is zero if the AND results in zero, and we don't force damage, then Agahnim's invincible!
 
 StandardSaveAndQuit:
 	LDA.b #$0F : STA.b $95 ; what we wrote over

--- a/tables.asm
+++ b/tables.asm
@@ -347,7 +347,11 @@ org $B0808A ; PC 0x18008A
 BlockCastleDoorsInRain:
 db $00 ; #$00 - Normal, $01 - Block them (Used by Entrance Rando in Standard Mode)
 ;--------------------------------------------------------------------------------
-; 0x18008B-0x18008D (unused)
+org $30808B ; PC 0x18008B
+AllowAgaDamageBeforeZeldaRescued:
+db #$00 ; #$00 - No damage, $01 - Damage (Used by Entrance Rando in Standard Mode)
+;--------------------------------------------------------------------------------
+; 0x18008C-0x18008D (unused)
 ;--------------------------------------------------------------------------------
 org $B0808E ; PC 0x18008E
 FakeBoots:


### PR DESCRIPTION
Not sure if the byte I used here is appropriate but wanted to get the fix on the books. 

Associated code for `Rom.py`

```python
if world.logic[player] == 'nologic':
    rom.write_byte(0x18008B, 0x01)
```